### PR TITLE
Minor linting tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ import (
  "net/http"
  "testing"
 
- _ "github.com/lib/pq"
  "github.com/pkg/errors"
  "github.com/wiremock/wiremock-testcontainers-go"
 )

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ More features will be added over time.
 
 import (
  "context"
- "io/ioutil"
  "net/http"
  "testing"
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/docker/go-connections v0.4.0
-	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1
 	github.com/testcontainers/testcontainers-go v0.21.0
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module example.com/m/v2
 go 1.19
 
 require (
+	github.com/docker/go-connections v0.4.0
 	github.com/lib/pq v1.10.9
+	github.com/pkg/errors v0.9.1
 	github.com/testcontainers/testcontainers-go v0.21.0
 
 )
@@ -16,7 +18,6 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v23.0.5+incompatible // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -31,7 +32,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHU
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=

--- a/tc-wiremock_test.go
+++ b/tc-wiremock_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/lib/pq"
 	"github.com/pkg/errors"
 )
 

--- a/tc-wiremock_test.go
+++ b/tc-wiremock_test.go
@@ -2,7 +2,7 @@ package testcontainers_wiremock
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -91,7 +91,7 @@ func SendHttpGet(url string, endpoint string) (int, string, error) {
 		return -1, "", errors.Wrap(err, "unable to complete Get request")
 	}
 
-	out, err := ioutil.ReadAll(res.Body)
+	out, err := io.ReadAll(res.Body)
 	if err != nil {
 		return -1, "", errors.Wrap(err, "unable to read response data")
 	}


### PR DESCRIPTION
As per discussion on Slack, a few minor tweaks that would be picked up by common linting rules in Go projects.

## References

- N/A

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide) **Note** there doesn't seem to be one?
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
