### PR TITLE
Use the official WireMock Docker image by default

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 on:
   push:
     branches: [ "main" ]
@@ -15,9 +15,6 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19
-
-    - name: Build image
-      run: make docker
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM wiremock/wiremock:2.35.0
-
-RUN mkdir /home/wiremock/mappings && mkdir /home/wiremock/__files 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: docker
-docker:
-	docker build -t wiremock/wiremock:2.35.0-for-tc .

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 [![Slack](https://img.shields.io/badge/slack-slack.wiremock.org-brightgreen?style=flat&logo=slack)](https://slack.wiremock.org/)
 [![GitHub contributors](https://img.shields.io/github/contributors/wiremock/wiremock-testcontainers-go)](https://github.com/wiremock/wiremock-testcontainers-go/graphs/contributors)
 
-## Note
-
-The Testcontainers module does not work with the official image at the moment,
-because the Mappings and Files directories are not initialized there.
-Use a custom image on the top of it, see `Dockerfile`.
+This module allows provisioning the WireMock server as a standalone container within your unit tests,
+based on [WireMock Docker](https://github.com/wiremock/wiremock-docker) `2.35.0-1` or above.
+Custom images are supported too as long as they follow the same CLI and API structure.
 
 ## Supported features
 

--- a/tc-wiremock.go
+++ b/tc-wiremock.go
@@ -10,7 +10,7 @@ import (
 )
 
 const defaultWireMockImage = "docker.io/wiremock/wiremock"
-const defaultWireMockVersion = "2.35.0-for-tc"
+const defaultWireMockVersion = "2.35.0-1"
 const defaultPort = "8080"
 
 type WireMockContainer struct {


### PR DESCRIPTION
After https://github.com/wiremock/wiremock-docker/releases/tag/2.35.0-1, the official image can be used 

Closes #2 