### PR TITLE
CI: Pin Go 1.19.10 version to avoid host validation issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.11
+        go-version: 1.19.10
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
For #18 
