### PR TITLE
Fix formatting and add missing link in quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,9 +2,9 @@
 
 If you have the Golang development environment ready to go and do not want a step by step guide,
 you can just clone the project’s repository in
-[wiremock/wiremock-testcontainers-go`](https://github.com/wiremock/wiremock-testcontainers-go),
+[`wiremock/wiremock-testcontainers-go`](https://github.com/wiremock/wiremock-testcontainers-go),
 go to the `examples/quickstart` directory
-and run `go build` and then `go test` in the root or try the examples].
+and run `go build` and then `go test` in the root or try the [examples](https://github.com/wiremock/wiremock-testcontainers-go/blob/main/examples/quickstart/quickstart_test.go).
 Any pull requests will be welcome ;-)
 
 ## Pre-requisites


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

While reading the documentation on GitHub, I came across some pretty weird formatting. It looks like one backtick sign was missing. After looking at .md file, I also found a single `]` sign after the word `examples`, I think that link to `https://github.com/wiremock/wiremock-testcontainers-go/blob/main/examples/quickstart/quickstart_test.go` should be placed there, so I also added that. If that wasn't intended, please let me know, and I will remove that :)

Screenshots before and after the change:
- before
![image](https://github.com/wiremock/wiremock-testcontainers-go/assets/87483058/3a90c3a7-3433-4139-918e-5336f3054338)
- after
![image](https://github.com/wiremock/wiremock-testcontainers-go/assets/87483058/47cb13a5-35b8-4e0e-9ed8-459e944f5acd)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
