### PR TITLE
Add API to simplify HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following features are now explicitly included in the module's API:
 
 - Passing API Mapping files
 - Passing Resource files
+- Sending HTTP requests to the mocked container
 
 More features will be added over time.
 
@@ -36,49 +37,42 @@ Just a teaser of how it feels at the real speed!
 
 ```golang
 import (
- "context"
- "github.com/pkg/errors"
- . "github.com/wiremock/wiremock-testcontainers-go"
- "io"
- http "net/http"
- "path/filepath"
- "testing"
+  "context"
+  . "github.com/wiremock/wiremock-testcontainers-go"
+  "testing"
 )
 
 func TestWireMock(t *testing.T) {
- // Create Container
- ctx := context.Background()
- container, err := RunContainer(ctx,
-  WithMappingFile("hello", filepath.Join("testdata", "hello-world.json")),
- )
- if err != nil {
-  t.Fatal(err)
- }
+	// Create Container
+	ctx := context.Background()
+	container, err := RunContainer(ctx,
+		WithMappingFile("hello", "hello-world.json"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
 
- // Clean up the container after the test is complete
- t.Cleanup(func() {
-  if err := container.Terminate(ctx); err != nil {
-   t.Fatalf("failed to terminate container: %s", err)
-  }
- })
+	// Clean up the container after the test is complete
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
 
- // Send the HTTP GET request
- uri, err := GetURI(ctx, container)
- if err != nil {
-  t.Fatal(err, "unable to get container endpoint")
- }
- statusCode, out, err := SendHttpGet(uri, "/hello")
- if err != nil {
-  t.Fatal(err, "Failed to get a response")
- }
+	// Send the HTTP GET request to the mocked API
+	statusCode, out, err := SendHttpGet(container, "/hello", nil)
+	if err != nil {
+		t.Fatal(err, "Failed to get a response")
+	}
 
- // Verify the response
- if statusCode != 200 {
-  t.Fatalf("expected HTTP-200 but got %d", statusCode)
- }
- if string(out) != "Hello, world!" {
-  t.Fatalf("expected 'Hello, world!' but got %v", string(out))
- }
+	// Verify the response
+	if statusCode != 200 {
+		t.Fatalf("expected HTTP-200 but got %d", statusCode)
+	}
+
+	if string(out) != "Hello, world!" {
+		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
+	}
 }
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,13 +38,9 @@ Add dependencies we will need for this demo, and also create the test stub:
 package testcontainers_wiremock_quickstart
 
 import (
- "context"
- "github.com/pkg/errors"
- . "github.com/wiremock/wiremock-testcontainers-go"
- "io"
- http "net/http"
- "path/filepath"
- "testing"
+  "context"
+  . "github.com/wiremock/wiremock-testcontainers-go"
+  "testing"
 )
 
 func TestWireMock(t *testing.T) {
@@ -96,47 +92,23 @@ t.Cleanup(func() {
 ## Add logic to send a request
 
 Now, we will need to send an HTTP request to our test API.
-To do so, we will need to use a utility method:
-
-<!-- TODO: Move it to the library -->
+To do so, we will use a build-in method:
 
 ```go
 func TestWireMock(t *testing.T) {
     // ... Previous initialization code
 
-    // Send a request to the mocked API
-    uri, err := GetURI(ctx, container)
-    if err != nil {
-        t.Fatal(err, "unable to get container endpoint")
-    }
-
-    statusCode, out, err := SendHttpGet(uri, "/hello")
+	// Send a simple HTTP GET request to the mocked API
+	statusCode, out, err := SendHttpGet(container, "/hello", nil)
     if err != nil {
         t.Fatal(err, "Failed to get a response")
     }
 
     // ... Validation will be here
 }
-
-func SendHttpGet(url string, endpoint string) (int, string, error) {
-    req, err := http.NewRequest(http.MethodGet, url+endpoint, nil)
-    if err != nil {
-        return -1, "", errors.Wrap(err, "unable to complete Get request")
-    }
-
-    res, err := http.DefaultClient.Do(req)
-    if err != nil {
-        return -1, "", errors.Wrap(err, "unable to complete Get request")
-    }
-
-    out, err := io.ReadAll(res.Body)
-    if err != nil {
-        return -1, "", errors.Wrap(err, "unable to read response data")
-    }
-
-    return res.StatusCode, string(out), nil
-}
 ```
+
+In the code above, we used the `SendHttpGet` method to send a HTTP GET request. The library also offers methods to send requests with other HTTP methods, i.e. `SendHttpPost`, `SendHttpDelete`,`SendHttpPatch`, `SendHttpPut`.  
 
 ## Verify the response
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,8 +98,8 @@ To do so, we will use a build-in method:
 func TestWireMock(t *testing.T) {
     // ... Previous initialization code
 
-	// Send a simple HTTP GET request to the mocked API
-	statusCode, out, err := SendHttpGet(container, "/hello", nil)
+    // Send a simple HTTP GET request to the mocked API
+    statusCode, out, err := SendHttpGet(container, "/hello", nil)
     if err != nil {
         t.Fatal(err, "Failed to get a response")
     }

--- a/examples/quickstart/go.mod
+++ b/examples/quickstart/go.mod
@@ -3,7 +3,6 @@ module wiremock.org/testcontainers-go-quickstart
 go 1.19
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/wiremock/wiremock-testcontainers-go v1.0.0-alpha-4
 )
 
@@ -39,3 +38,5 @@ require (
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )
+
+replace github.com/wiremock/wiremock-testcontainers-go => ../../../wiremock-testcontainers-go // needed to use new method written localy in the quickstart_test.go

--- a/examples/quickstart/quickstart_test.go
+++ b/examples/quickstart/quickstart_test.go
@@ -2,10 +2,7 @@ package testcontainers_wiremock_quickstart
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	. "github.com/wiremock/wiremock-testcontainers-go"
-	"io"
-	http "net/http"
 	"testing"
 )
 
@@ -26,13 +23,8 @@ func TestWireMock(t *testing.T) {
 		}
 	})
 
-	// Send a request to the mocked API
-	uri, err := GetURI(ctx, container)
-	if err != nil {
-		t.Fatal(err, "unable to get container endpoint")
-	}
-
-	statusCode, out, err := SendHttpGet(uri, "/hello")
+	// Send a simple HTTP GET request to the mocked API
+	statusCode, out, err := SendHttpGet(container, "/hello", nil)
 	if err != nil {
 		t.Fatal(err, "Failed to get a response")
 	}
@@ -45,23 +37,4 @@ func TestWireMock(t *testing.T) {
 	if string(out) != "Hello, world!" {
 		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
 	}
-}
-
-func SendHttpGet(url string, endpoint string) (int, string, error) {
-	req, err := http.NewRequest(http.MethodGet, url+endpoint, nil)
-	if err != nil {
-		return -1, "", errors.Wrap(err, "unable to complete Get request")
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return -1, "", errors.Wrap(err, "unable to complete Get request")
-	}
-
-	out, err := io.ReadAll(res.Body)
-	if err != nil {
-		return -1, "", errors.Wrap(err, "unable to read response data")
-	}
-
-	return res.StatusCode, string(out), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/docker/go-connections v0.4.0
-	github.com/pkg/errors v0.9.1
 	github.com/testcontainers/testcontainers-go v0.21.0
 
 )
@@ -31,6 +30,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/net v0.7.0 // indirect

--- a/tc-wiremock_test.go
+++ b/tc-wiremock_test.go
@@ -1,14 +1,11 @@
 package testcontainers_wiremock
 
 import (
+	"bytes"
 	"context"
-	"io"
-	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 func TestWireMock(t *testing.T) {
@@ -28,12 +25,7 @@ func TestWireMock(t *testing.T) {
 		}
 	})
 
-	uri, err := GetURI(ctx, container)
-	if err != nil {
-		t.Fatal(err, "unable to get container endpoint")
-	}
-
-	statusCode, out, err := SendHttpGet(uri, "/hello")
+	statusCode, out, err := SendHttpGet(container, "/hello", nil)
 	if err != nil {
 		t.Fatal(err, "Failed to get a response")
 	}
@@ -63,12 +55,7 @@ func TestWireMockWithResource(t *testing.T) {
 		}
 	})
 
-	uri, err := GetURI(ctx, container)
-	if err != nil {
-		t.Fatal(err, "unable to get container endpoint")
-	}
-
-	statusCode, out, err := SendHttpGet(uri, "/hello-from-file")
+	statusCode, out, err := SendHttpGet(container, "/hello-from-file", nil)
 	if err != nil {
 		t.Fatal(err, "Failed to get a response")
 	}
@@ -80,21 +67,151 @@ func TestWireMockWithResource(t *testing.T) {
 	}
 }
 
-func SendHttpGet(url string, endpoint string) (int, string, error) {
-	req, err := http.NewRequest(http.MethodGet, url+endpoint, nil)
+func TestSendHttpGetWorksWithQueryParamsPassedInArgument(t *testing.T) {
+	// Create Container
+	ctx := context.Background()
+	container, err := RunContainer(ctx,
+		WithMappingFile("get", filepath.Join("testdata", "url-with-query-params.json")),
+	)
 	if err != nil {
-		return -1, "", errors.Wrap(err, "unable to complete Get request")
+		t.Fatal(err)
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	// Clean up the container after the test is complete
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	statusCode, out, err := SendHttpGet(container, "/get", map[string]string{"query": "test"})
 	if err != nil {
-		return -1, "", errors.Wrap(err, "unable to complete Get request")
+		t.Fatal(err, "Failed to get a response")
+	}
+	if statusCode != 200 {
+		t.Fatalf("expected HTTP-200 but got %d", statusCode)
+	}
+	if out != "" {
+		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
+	}
+}
+
+func TestSendHttpGetWorksWithQueryParamsProvidedInURL(t *testing.T) {
+	// Create Container
+	ctx := context.Background()
+	container, err := RunContainer(ctx,
+		WithMappingFile("get", filepath.Join("testdata", "url-with-query-params.json")),
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	out, err := io.ReadAll(res.Body)
+	// Clean up the container after the test is complete
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	statusCode, out, err := SendHttpGet(container, "/get?query=test", nil)
 	if err != nil {
-		return -1, "", errors.Wrap(err, "unable to read response data")
+		t.Fatal(err, "Failed to get a response")
+	}
+	if statusCode != 200 {
+		t.Fatalf("expected HTTP-200 but got %d", statusCode)
+	}
+	if out != "" {
+		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
+	}
+}
+
+func TestSendHttpDelete(t *testing.T) {
+	// Create Container
+	ctx := context.Background()
+	container, err := RunContainer(ctx,
+		WithMappingFile("delete", filepath.Join("testdata", "204-no-content.json")),
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	return res.StatusCode, string(out), nil
+	// Clean up the container after the test is complete
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	statusCode, out, err := SendHttpDelete(container, "/delete")
+	if err != nil {
+		t.Fatal(err, "Failed to get a response")
+	}
+	if statusCode != 204 {
+		t.Fatalf("expected HTTP-200 but got %d", statusCode)
+	}
+	if out != "" {
+		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
+	}
+}
+
+func TestSendHttpPatch(t *testing.T) {
+	// Create Container
+	ctx := context.Background()
+	container, err := RunContainer(ctx,
+		WithMappingFile("patch", filepath.Join("testdata", "200-patch.json")),
+		WithFile("sample-model.json", filepath.Join("testdata", "sample-model.json")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean up the container after the test is complete
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	var jsonBody = []byte(`{"title":"Buy cheese and bread for breakfast."}`)
+	statusCode, out, err := SendHttpPatch(container, "/patch", bytes.NewBuffer(jsonBody))
+	if err != nil {
+		t.Fatal(err, "Failed to get a response")
+	}
+	if statusCode != 200 {
+		t.Fatalf("expected HTTP-200 but got %d", statusCode)
+	}
+	if !strings.Contains(out, "sampleField1") {
+		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
+	}
+}
+
+func TestSendHttpPut(t *testing.T) {
+	// Create Container
+	ctx := context.Background()
+	container, err := RunContainer(ctx,
+		WithMappingFile("put", filepath.Join("testdata", "200-put.json")),
+		WithFile("sample-model.json", filepath.Join("testdata", "sample-model.json")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean up the container after the test is complete
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	var jsonBody = []byte(`{"title":"Buy cheese and bread for breakfast."}`)
+	statusCode, out, err := SendHttpPut(container, "/put", bytes.NewBuffer(jsonBody))
+	if err != nil {
+		t.Fatal(err, "Failed to get a response")
+	}
+	if statusCode != 200 {
+		t.Fatalf("expected HTTP-200 but got %d", statusCode)
+	}
+	if !strings.Contains(out, "sampleField1") {
+		t.Fatalf("expected 'Hello, world!' but got %v", string(out))
+	}
 }

--- a/testdata/200-patch.json
+++ b/testdata/200-patch.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "method": "PATCH",
+    "url": "/patch"
+  },
+
+  "response": {
+    "status": 200,
+    "bodyFileName": "sample-model.json"
+  }
+}

--- a/testdata/200-put.json
+++ b/testdata/200-put.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "method": "PUT",
+    "url": "/put"
+  },
+
+  "response": {
+    "status": 200,
+    "bodyFileName": "sample-model.json"
+  }
+}

--- a/testdata/201-created.json
+++ b/testdata/201-created.json
@@ -1,0 +1,11 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/create"
+  },
+
+  "response": {
+    "status": 201,
+    "bodyFileName": "sample-model.json"
+  }
+}

--- a/testdata/204-no-content.json
+++ b/testdata/204-no-content.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "DELETE",
+    "url": "/delete"
+  },
+
+  "response": {
+    "status": 204
+  }
+}

--- a/testdata/sample-model.json
+++ b/testdata/sample-model.json
@@ -1,0 +1,4 @@
+{
+  "sampleField1" : "sampleVal1",
+  "sampleField2" : "sampleVal2"
+}

--- a/testdata/url-with-query-params.json
+++ b/testdata/url-with-query-params.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/get?query=test"
+  },
+
+  "response": {
+    "status": 200
+  }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Implementation of the enhancement proposed in issue #17 

Following methods were added: `SendHttpGet`, `SendHttpDelete`, `SendHttpPost`, `SendHttpPatch`, `SendHttpPut`. All of them are taking `testcontainers.Container` as a one of the arguments, form which the container URI is extracted.

I'm putting it as a draft PR, as the documentation part is still missing, but I would really appreciate early feedback :) 

#### More details
Each method takes arguments appropriate for the given HTTP method, e.g., `SendHttpGet` takes additional `queryParams` (type `map[string]string`), but doesn't take the `body` argument. Query parms are also working when they are hardcoded in the URL itself - included in the test case.

### Tasks from the issue description
- [x] Update the code
- [x] Update the tests to use the new helpers
- [x] Update the readme and the quick start guide
## References
#17 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
