### PR TITLE
Fix the release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
+name: Publish the Release
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
     contents: write


### PR DESCRIPTION
The previous trigger was wrong. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

<!-- Please describe your pull request here. -->

## References

- [TODO](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
