### PR TITLE
Fix filepath join on windows

### DIFF
--- a/tc-wiremock.go
+++ b/tc-wiremock.go
@@ -94,7 +94,7 @@ func WithMappingFile(id string, filePath string) testcontainers.CustomizeRequest
 	return func(req *testcontainers.GenericContainerRequest) error {
 		cfgFile := testcontainers.ContainerFile{
 			HostFilePath:      filePath,
-			ContainerFilePath: filepath.Join("/home/wiremock/mappings", id+".json"),
+			ContainerFilePath: "/home/wiremock/mappings/" + id + ".json",
 			FileMode:          0755,
 		}
 


### PR DESCRIPTION
This PR fixes #38 by not using `filepath.Join` but joining the path by string concatenation. 

## References

- #38 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
