### PR TITLE
Change RunDefaultContainerAndStopOnCleanup to use the interface testing.TB

### DIFF
--- a/tc-wiremock-v3_test.go
+++ b/tc-wiremock-v3_test.go
@@ -436,7 +436,7 @@ func TestV3Auth(t *testing.T) {
 	}
 }
 
-func sendTestRequest(t *testing.T, req *http.Request) (int, string, error) {
+func sendTestRequest(t testing.TB, req *http.Request) (int, string, error) {
 	t.Helper()
 
 	resp, err := http.DefaultClient.Do(req)

--- a/tc-wiremock.go
+++ b/tc-wiremock.go
@@ -67,7 +67,7 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 }
 
 // Creates an instance of the WireMockContainer type that is automatically terminated upon test completion
-func RunContainerAndStopOnCleanup(ctx context.Context, t *testing.T, opts ...testcontainers.ContainerCustomizer) (*WireMockContainer, error) {
+func RunContainerAndStopOnCleanup(ctx context.Context, t testing.TB, opts ...testcontainers.ContainerCustomizer) (*WireMockContainer, error) {
 	container, err := RunContainer(ctx, opts...)
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +84,7 @@ func RunContainerAndStopOnCleanup(ctx context.Context, t *testing.T, opts ...tes
 }
 
 // Creates a default instance of the WireMockContainer type that is automatically terminated upon test completion
-func RunDefaultContainerAndStopOnCleanup(ctx context.Context, t *testing.T) (*WireMockContainer, error) {
+func RunDefaultContainerAndStopOnCleanup(ctx context.Context, t testing.TB) (*WireMockContainer, error) {
 	var emptyCustomizers []testcontainers.ContainerCustomizer
 	return RunContainerAndStopOnCleanup(ctx, t, emptyCustomizers...)
 }


### PR DESCRIPTION
This allows test-containers to be used in benchmark setup code.
While it's generally recommended to isolate the code one is benchmarking, profiling the end to end logic of a handler can still reveal bottlenecks and extra memory allocations.

This change is backwards compatible, as *testing.T is an implementation of testing.TB.

## References

- interface [testing.TB](https://pkg.go.dev/testing#TB)


## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
