### PR TITLE
Drop support for Golang 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
       matrix:
         version:
-          - "1.23"
+          - "1.25"
+          # Minimum version, aligned with the Testcontainers lib
           - "1.24"
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Updated Go version in CI workflow from 1.23 to 1.25.

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
